### PR TITLE
NIFI-3380: Service APIs

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ControllerServiceApiDTO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ControllerServiceApiDTO.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.api.dto;
+
+import com.wordnik.swagger.annotations.ApiModelProperty;
+
+import javax.xml.bind.annotation.XmlType;
+import java.util.Objects;
+
+/**
+ * Class used for providing details of a Controller Service API.
+ */
+@XmlType(name = "controllerServiceApi")
+public class ControllerServiceApiDTO {
+
+    private String type;
+    private BundleDTO bundle;
+
+    /**
+     * @return The type is the fully-qualified name of the service interface
+     */
+    @ApiModelProperty(
+            value = "The fully qualified name of the service interface."
+    )
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    /**
+     * The details of the artifact that bundled this service interface.
+     *
+     * @return The bundle details
+     */
+    @ApiModelProperty(
+            value = "The details of the artifact that bundled this service interface."
+    )
+    public BundleDTO getBundle() {
+        return bundle;
+    }
+
+    public void setBundle(BundleDTO bundle) {
+        this.bundle = bundle;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final ControllerServiceApiDTO that = (ControllerServiceApiDTO) o;
+        return Objects.equals(type, that.type) && Objects.equals(bundle, that.bundle);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, bundle);
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ControllerServiceDTO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ControllerServiceDTO.java
@@ -21,6 +21,7 @@ import org.apache.nifi.web.api.entity.ControllerServiceReferencingComponentEntit
 
 import javax.xml.bind.annotation.XmlType;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -33,11 +34,13 @@ public class ControllerServiceDTO extends ComponentDTO {
     private String name;
     private String type;
     private BundleDTO bundle;
+    private List<ControllerServiceApiDTO> controllerServiceApis;
     private String comments;
     private String state;
     private Boolean persistsState;
     private Boolean restricted;
     private Boolean isExtensionMissing;
+    private Boolean multipleVersionsAvailable;
 
     private Map<String, String> properties;
     private Map<String, PropertyDescriptorDTO> descriptors;
@@ -94,6 +97,22 @@ public class ControllerServiceDTO extends ComponentDTO {
     }
 
     /**
+     * Lists the APIs this Controller Service implements.
+     *
+     * @return The listing of implemented APIs
+     */
+    @ApiModelProperty(
+            value = "Lists the APIs this Controller Service implements."
+    )
+    public List<ControllerServiceApiDTO> getControllerServiceApis() {
+        return controllerServiceApis;
+    }
+
+    public void setControllerServiceApis(List<ControllerServiceApiDTO> controllerServiceApis) {
+        this.controllerServiceApis = controllerServiceApis;
+    }
+
+    /**
      * @return the comment for the Controller Service
      */
     @ApiModelProperty(
@@ -147,6 +166,20 @@ public class ControllerServiceDTO extends ComponentDTO {
 
     public void setExtensionMissing(Boolean extensionMissing) {
         isExtensionMissing = extensionMissing;
+    }
+
+    /**
+     * @return whether this controller service has multiple versions available
+     */
+    @ApiModelProperty(
+            value = "Whether the controller service has multiple versions available."
+    )
+    public Boolean getMultipleVersionsAvailable() {
+        return multipleVersionsAvailable;
+    }
+
+    public void setMultipleVersionsAvailable(Boolean multipleVersionsAvailable) {
+        this.multipleVersionsAvailable = multipleVersionsAvailable;
     }
 
     /**

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/DocumentedTypeDTO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/DocumentedTypeDTO.java
@@ -19,6 +19,7 @@ package org.apache.nifi.web.api.dto;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 
 import javax.xml.bind.annotation.XmlType;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -30,6 +31,7 @@ public class DocumentedTypeDTO {
 
     private String type;
     private BundleDTO bundle;
+    private List<ControllerServiceApiDTO> controllerServiceApis;
     private String description;
     private String usageRestriction;
     private Set<String> tags;
@@ -90,6 +92,22 @@ public class DocumentedTypeDTO {
 
     public void setBundle(BundleDTO bundle) {
         this.bundle = bundle;
+    }
+
+    /**
+     * If this type represents a ControllerService, this lists the APIs it implements.
+     *
+     * @return The listing of implemented APIs
+     */
+    @ApiModelProperty(
+            value = "If this type represents a ControllerService, this lists the APIs it implements."
+    )
+    public List<ControllerServiceApiDTO> getControllerServiceApis() {
+        return controllerServiceApis;
+    }
+
+    public void setControllerServiceApis(List<ControllerServiceApiDTO> controllerServiceApis) {
+        this.controllerServiceApis = controllerServiceApis;
     }
 
     /**

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ProcessorDTO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ProcessorDTO.java
@@ -42,6 +42,7 @@ public class ProcessorDTO extends ComponentDTO {
     private Boolean persistsState;
     private Boolean restricted;
     private Boolean isExtensionMissing;
+    private Boolean multipleVersionsAvailable;
     private String inputRequirement;
 
     private ProcessorConfigDTO config;
@@ -155,6 +156,20 @@ public class ProcessorDTO extends ComponentDTO {
 
     public void setPersistsState(Boolean persistsState) {
         this.persistsState = persistsState;
+    }
+
+    /**
+     * @return whether this processor has multiple versions available
+     */
+    @ApiModelProperty(
+            value = "Whether the processor has multiple versions available."
+    )
+    public Boolean getMultipleVersionsAvailable() {
+        return multipleVersionsAvailable;
+    }
+
+    public void setMultipleVersionsAvailable(Boolean multipleVersionsAvailable) {
+        this.multipleVersionsAvailable = multipleVersionsAvailable;
     }
 
     /**

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/PropertyDescriptorDTO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/PropertyDescriptorDTO.java
@@ -19,8 +19,8 @@ package org.apache.nifi.web.api.dto;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 import org.apache.nifi.web.api.entity.AllowableValueEntity;
 
-import java.util.List;
 import javax.xml.bind.annotation.XmlType;
+import java.util.List;
 
 /**
  * A description of a property.
@@ -38,6 +38,7 @@ public class PropertyDescriptorDTO {
     private Boolean dynamic;
     private Boolean supportsEl;
     private String identifiesControllerService;
+    private BundleDTO identifiesControllerServiceBundle;
 
     /**
      * @return set of allowable values for this property. If empty then the allowable values are not constrained
@@ -166,10 +167,10 @@ public class PropertyDescriptorDTO {
     }
 
     /**
-     * @return if this property identifies a controller service, this returns the fully qualified type, null otherwise
+     * @return if this property identifies a controller service this returns the fully qualified type, null otherwise
      */
     @ApiModelProperty(
-            value = "If the property identifies a controller service, this returns the fully qualified type."
+            value = "If the property identifies a controller service this returns the fully qualified type."
     )
     public String getIdentifiesControllerService() {
         return identifiesControllerService;
@@ -179,4 +180,17 @@ public class PropertyDescriptorDTO {
         this.identifiesControllerService = identifiesControllerService;
     }
 
+    /**
+     * @return if this property identifies a controller service this returns the bundle of the type, null otherwise
+     */
+    @ApiModelProperty(
+            value = "If the property identifies a controller service this returns the bundle of the type, null otherwise."
+    )
+    public BundleDTO getIdentifiesControllerServiceBundle() {
+        return identifiesControllerServiceBundle;
+    }
+
+    public void setIdentifiesControllerServiceBundle(BundleDTO identifiesControllerServiceBundle) {
+        this.identifiesControllerServiceBundle = identifiesControllerServiceBundle;
+    }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ReportingTaskDTO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ReportingTaskDTO.java
@@ -36,6 +36,7 @@ public class ReportingTaskDTO extends ComponentDTO {
     private Boolean persistsState;
     private Boolean restricted;
     private Boolean isExtensionMissing;
+    private Boolean multipleVersionsAvailable;
 
     private String schedulingPeriod;
     private String schedulingStrategy;
@@ -164,6 +165,20 @@ public class ReportingTaskDTO extends ComponentDTO {
 
     public void setExtensionMissing(Boolean extensionMissing) {
         isExtensionMissing = extensionMissing;
+    }
+
+    /**
+     * @return whether this reporting task has multiple versions available
+     */
+    @ApiModelProperty(
+            value = "Whether the reporting task has multiple versions available."
+    )
+    public Boolean getMultipleVersionsAvailable() {
+        return multipleVersionsAvailable;
+    }
+
+    public void setMultipleVersionsAvailable(Boolean multipleVersionsAvailable) {
+        this.multipleVersionsAvailable = multipleVersionsAvailable;
     }
 
     /**

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiServiceFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiServiceFacade.java
@@ -328,33 +328,37 @@ public interface NiFiServiceFacade {
     /**
      * Returns the list of processor types.
      *
-     * @param bundleGroup if specified, must be member of bundle group
-     * @param bundleArtifact if specified, must be member of bundle artifact
-     * @param type if specified, type must match
+     * @param bundleGroupFilter if specified, must be member of bundle group
+     * @param bundleArtifactFilter if specified, must be member of bundle artifact
+     * @param typeFilter if specified, type must match
      * @return The list of available processor types matching specified criteria
      */
-    Set<DocumentedTypeDTO> getProcessorTypes(final String bundleGroup, final String bundleArtifact, final String type);
+    Set<DocumentedTypeDTO> getProcessorTypes(final String bundleGroupFilter, final String bundleArtifactFilter, final String typeFilter);
 
     /**
      * Returns the list of controller service types.
      *
      * @param serviceType Filters only service types that implement this type
-     * @param bundleGroup if specified, must be member of bundle group
-     * @param bundleArtifact if specified, must be member of bundle artifact
-     * @param type if specified, type must match
+     * @param serviceBundleGroup if serviceType specified, the bundle group of the serviceType
+     * @param serviceBundleArtifact if serviceType specified, the bundle artifact of the serviceType
+     * @param serviceBundleVersion if serviceType specified, the bundle version of the serviceType
+     * @param bundleGroupFilter if specified, must be member of bundle group
+     * @param bundleArtifactFilter if specified, must be member of bundle artifact
+     * @param typeFilter if specified, type must match
      * @return The list of available controller types matching specified criteria
      */
-    Set<DocumentedTypeDTO> getControllerServiceTypes(String serviceType, final String bundleGroup, final String bundleArtifact, final String type);
+    Set<DocumentedTypeDTO> getControllerServiceTypes(final String serviceType, final String serviceBundleGroup, final String serviceBundleArtifact, final String serviceBundleVersion,
+                                                     final String bundleGroupFilter, final String bundleArtifactFilter, final String typeFilter);
 
     /**
      * Returns the list of reporting task types.
      *
-     * @param bundleGroup if specified, must be member of bundle group
-     * @param bundleArtifact if specified, must be member of bundle artifact
-     * @param type if specified, type must match
+     * @param bundleGroupFilter if specified, must be member of bundle group
+     * @param bundleArtifactFilter if specified, must be member of bundle artifact
+     * @param typeFilter if specified, type must match
      * @return The list of available reporting task types matching specified criteria
      */
-    Set<DocumentedTypeDTO> getReportingTaskTypes(final String bundleGroup, final String bundleArtifact, final String type);
+    Set<DocumentedTypeDTO> getReportingTaskTypes(final String bundleGroupFilter, final String bundleArtifactFilter, final String typeFilter);
 
     /**
      * Returns the list of prioritizer types.

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
@@ -2391,8 +2391,9 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
     }
 
     @Override
-    public Set<DocumentedTypeDTO> getControllerServiceTypes(final String serviceType, final String bundleGroup, final String bundleArtifact, final String type) {
-        return controllerFacade.getControllerServiceTypes(serviceType, bundleGroup, bundleArtifact, type);
+    public Set<DocumentedTypeDTO> getControllerServiceTypes(final String serviceType, final String serviceBundleGroup, final String serviceBundleArtifact, final String serviceBundleVersion,
+                                                            final String bundleGroup, final String bundleArtifact, final String type) {
+        return controllerFacade.getControllerServiceTypes(serviceType, serviceBundleGroup, serviceBundleArtifact, serviceBundleVersion, bundleGroup, bundleArtifact, type);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/FlowResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/FlowResource.java
@@ -933,17 +933,17 @@ public class FlowResource extends ApplicationResource {
                 value = "If specified, will only return types that are a member of this bundle group.",
                 required = false
             )
-            @QueryParam("bundleGroup") String bundleGroup,
+            @QueryParam("bundleGroupFilter") String bundleGroupFilter,
             @ApiParam(
                     value = "If specified, will only return types that are a member of this bundle artifact.",
                     required = false
             )
-            @QueryParam("bundleArtifact") String bundleArtifact,
+            @QueryParam("bundleArtifactFilter") String bundleArtifactFilter,
             @ApiParam(
                     value = "If specified, will only return types whose fully qualified classname matches.",
                     required = false
             )
-            @QueryParam("type") String type) throws InterruptedException {
+            @QueryParam("type") String typeFilter) throws InterruptedException {
 
         authorizeFlow();
 
@@ -953,7 +953,7 @@ public class FlowResource extends ApplicationResource {
 
         // create response entity
         final ProcessorTypesEntity entity = new ProcessorTypesEntity();
-        entity.setProcessorTypes(serviceFacade.getProcessorTypes(bundleGroup, bundleArtifact, type));
+        entity.setProcessorTypes(serviceFacade.getProcessorTypes(bundleGroupFilter, bundleArtifactFilter, typeFilter));
 
         // generate the response
         return clusterContext(generateOkResponse(entity)).build();
@@ -993,22 +993,43 @@ public class FlowResource extends ApplicationResource {
             )
             @QueryParam("serviceType") String serviceType,
             @ApiParam(
+                    value = "If serviceType specified, is the bundle group of the serviceType.",
+                    required = false
+            )
+            @QueryParam("serviceBundleGroup") String serviceBundleGroup,
+            @ApiParam(
+                    value = "If serviceType specified, is the bundle artifact of the serviceType.",
+                    required = false
+            )
+            @QueryParam("serviceBundleArtifact") String serviceBundleArtifact,
+            @ApiParam(
+                    value = "If serviceType specified, is the bundle version of the serviceType.",
+                    required = false
+            )
+            @QueryParam("serviceBundleVersion") String serviceBundleVersion,
+            @ApiParam(
                     value = "If specified, will only return types that are a member of this bundle group.",
                     required = false
             )
-            @QueryParam("bundleGroup") String bundleGroup,
+            @QueryParam("bundleGroupFilter") String bundleGroupFilter,
             @ApiParam(
                     value = "If specified, will only return types that are a member of this bundle artifact.",
                     required = false
             )
-            @QueryParam("bundleArtifact") String bundleArtifact,
+            @QueryParam("bundleArtifactFilter") String bundleArtifactFilter,
             @ApiParam(
                     value = "If specified, will only return types whose fully qualified classname matches.",
                     required = false
             )
-            @QueryParam("type") String type) throws InterruptedException {
+            @QueryParam("typeFilter") String typeFilter) throws InterruptedException {
 
         authorizeFlow();
+
+        if (serviceType != null) {
+            if (serviceBundleGroup == null || serviceBundleArtifact == null || serviceBundleVersion == null) {
+                throw new IllegalArgumentException("When specifying the serviceType the serviceBundleGroup, serviceBundleArtifact, and serviceBundleVersion must be specified.");
+            }
+        }
 
         if (isReplicateRequest()) {
             return replicate(HttpMethod.GET);
@@ -1016,7 +1037,8 @@ public class FlowResource extends ApplicationResource {
 
         // create response entity
         final ControllerServiceTypesEntity entity = new ControllerServiceTypesEntity();
-        entity.setControllerServiceTypes(serviceFacade.getControllerServiceTypes(serviceType, bundleGroup, bundleArtifact, type));
+        entity.setControllerServiceTypes(serviceFacade.getControllerServiceTypes(serviceType, serviceBundleGroup, serviceBundleArtifact, serviceBundleVersion,
+                bundleGroupFilter, bundleArtifactFilter, typeFilter));
 
         // generate the response
         return clusterContext(generateOkResponse(entity)).build();
@@ -1053,17 +1075,17 @@ public class FlowResource extends ApplicationResource {
                     value = "If specified, will only return types that are a member of this bundle group.",
                     required = false
             )
-            @QueryParam("bundleGroup") String bundleGroup,
+            @QueryParam("bundleGroupFilter") String bundleGroupFilter,
             @ApiParam(
                     value = "If specified, will only return types that are a member of this bundle artifact.",
                     required = false
             )
-            @QueryParam("bundleArtifact") String bundleArtifact,
+            @QueryParam("bundleArtifactFilter") String bundleArtifactFilter,
             @ApiParam(
                     value = "If specified, will only return types whose fully qualified classname matches.",
                     required = false
             )
-            @QueryParam("type") String type) throws InterruptedException {
+            @QueryParam("type") String typeFilter) throws InterruptedException {
 
         authorizeFlow();
 
@@ -1073,7 +1095,7 @@ public class FlowResource extends ApplicationResource {
 
         // create response entity
         final ReportingTaskTypesEntity entity = new ReportingTaskTypesEntity();
-        entity.setReportingTaskTypes(serviceFacade.getReportingTaskTypes(bundleGroup, bundleArtifact, type));
+        entity.setReportingTaskTypes(serviceFacade.getReportingTaskTypes(bundleGroupFilter, bundleArtifactFilter, typeFilter));
 
         // generate the response
         return clusterContext(generateOkResponse(entity)).build();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.web.api.dto;
 
+import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.action.Action;
 import org.apache.nifi.action.component.details.ComponentDetails;
@@ -1234,11 +1235,17 @@ public final class DtoFactory {
     }
 
     public ReportingTaskDTO createReportingTaskDto(final ReportingTaskNode reportingTaskNode) {
+        final BundleCoordinate bundleCoordinate = reportingTaskNode.getBundleCoordinate();
+        final List<Bundle> compatibleBundles = ExtensionManager.getBundles(reportingTaskNode.getCanonicalClassName()).stream().filter(bundle -> {
+            final BundleCoordinate coordinate = bundle.getBundleDetails().getCoordinate();
+            return bundleCoordinate.getGroup().equals(coordinate.getGroup()) && bundleCoordinate.getId().equals(coordinate.getId());
+        }).collect(Collectors.toList());
+
         final ReportingTaskDTO dto = new ReportingTaskDTO();
         dto.setId(reportingTaskNode.getIdentifier());
         dto.setName(reportingTaskNode.getName());
         dto.setType(reportingTaskNode.getCanonicalClassName());
-        dto.setBundle(createBundleDto(reportingTaskNode.getBundleCoordinate()));
+        dto.setBundle(createBundleDto(bundleCoordinate));
         dto.setSchedulingStrategy(reportingTaskNode.getSchedulingStrategy().name());
         dto.setSchedulingPeriod(reportingTaskNode.getSchedulingPeriod());
         dto.setState(reportingTaskNode.getScheduledState().name());
@@ -1248,6 +1255,7 @@ public final class DtoFactory {
         dto.setPersistsState(reportingTaskNode.getReportingTask().getClass().isAnnotationPresent(Stateful.class));
         dto.setRestricted(reportingTaskNode.isRestricted());
         dto.setExtensionMissing(reportingTaskNode.isExtensionMissing());
+        dto.setMultipleVersionsAvailable(compatibleBundles.size() > 1);
 
         final Map<String, String> defaultSchedulingPeriod = new HashMap<>();
         defaultSchedulingPeriod.put(SchedulingStrategy.TIMER_DRIVEN.name(), SchedulingStrategy.TIMER_DRIVEN.getDefaultSchedulingPeriod());
@@ -1308,18 +1316,26 @@ public final class DtoFactory {
     }
 
     public ControllerServiceDTO createControllerServiceDto(final ControllerServiceNode controllerServiceNode) {
+        final BundleCoordinate bundleCoordinate = controllerServiceNode.getBundleCoordinate();
+        final List<Bundle> compatibleBundles = ExtensionManager.getBundles(controllerServiceNode.getCanonicalClassName()).stream().filter(bundle -> {
+            final BundleCoordinate coordinate = bundle.getBundleDetails().getCoordinate();
+            return bundleCoordinate.getGroup().equals(coordinate.getGroup()) && bundleCoordinate.getId().equals(coordinate.getId());
+        }).collect(Collectors.toList());
+
         final ControllerServiceDTO dto = new ControllerServiceDTO();
         dto.setId(controllerServiceNode.getIdentifier());
         dto.setParentGroupId(controllerServiceNode.getProcessGroup() == null ? null : controllerServiceNode.getProcessGroup().getIdentifier());
         dto.setName(controllerServiceNode.getName());
         dto.setType(controllerServiceNode.getCanonicalClassName());
         dto.setBundle(createBundleDto(controllerServiceNode.getBundleCoordinate()));
+        dto.setControllerServiceApis(createControllerServiceApiDto(controllerServiceNode.getControllerServiceImplementation().getClass()));
         dto.setState(controllerServiceNode.getState().name());
         dto.setAnnotationData(controllerServiceNode.getAnnotationData());
         dto.setComments(controllerServiceNode.getComments());
         dto.setPersistsState(controllerServiceNode.getControllerServiceImplementation().getClass().isAnnotationPresent(Stateful.class));
         dto.setRestricted(controllerServiceNode.isRestricted());
         dto.setExtensionMissing(controllerServiceNode.isExtensionMissing());
+        dto.setMultipleVersionsAvailable(compatibleBundles.size() > 1);
 
         // sort a copy of the properties
         final Map<PropertyDescriptor, String> sortedProperties = new TreeMap<>(new Comparator<PropertyDescriptor>() {
@@ -2066,44 +2082,93 @@ public final class DtoFactory {
         return dto;
     }
 
+    private List<ControllerServiceApiDTO> createControllerServiceApiDto(final Class cls) {
+        final Set<Class> serviceApis = new HashSet<>();
+
+        // if this is a controller service
+        if (ControllerService.class.isAssignableFrom(cls)) {
+            // get all of it's interfaces to determine the controller service api's it implements
+            final List<Class<?>> interfaces = ClassUtils.getAllInterfaces(cls);
+            for (final Class i : interfaces) {
+                // add all controller services that's not ControllerService itself
+                if (ControllerService.class.isAssignableFrom(i) && !ControllerService.class.equals(i)) {
+                    serviceApis.add(i);
+                }
+            }
+
+            final List<ControllerServiceApiDTO> dtos = new ArrayList<>();
+            for (final Class serviceApi : serviceApis) {
+                final Bundle bundle = ExtensionManager.getBundle(serviceApi.getClassLoader());
+                final BundleCoordinate bundleCoordinate = bundle.getBundleDetails().getCoordinate();
+
+                final ControllerServiceApiDTO dto = new ControllerServiceApiDTO();
+                dto.setType(serviceApi.getName());
+                dto.setBundle(createBundleDto(bundleCoordinate));
+                dtos.add(dto);
+            }
+            return dtos;
+        } else {
+            return null;
+        }
+    }
+
     /**
      * Gets the DocumentedTypeDTOs from the specified classes.
      *
      * @param classes classes
+     * @param bundleGroupFilter if specified, must be member of bundle group
+     * @param bundleArtifactFilter if specified, must be member of bundle artifact
+     * @param typeFilter if specified, type must match
      * @return dtos
      */
-    @SuppressWarnings("rawtypes")
-    public Set<DocumentedTypeDTO> fromDocumentedTypes(final Set<Class> classes, final String bundleGroup, final String bundleArtifact, final String type) {
+    public Set<DocumentedTypeDTO> fromDocumentedTypes(final Map<Class, Bundle> classes, final String bundleGroupFilter, final String bundleArtifactFilter, final String typeFilter) {
         final Set<DocumentedTypeDTO> types = new LinkedHashSet<>();
-        final Set<Class> sortedClasses = new TreeSet<>(CLASS_NAME_COMPARATOR);
-        sortedClasses.addAll(classes);
+        final List<Class> sortedClasses = new ArrayList<>(classes.keySet());
+        Collections.sort(sortedClasses, CLASS_NAME_COMPARATOR);
 
-        for (final Class<?> cls : sortedClasses) {
-            for (final Bundle bundle : ExtensionManager.getBundles(cls.getName())) {
-                final BundleCoordinate coordinate = bundle.getBundleDetails().getCoordinate();
+        for (final Class cls : sortedClasses) {
+            final Bundle bundle = classes.get(cls);
+            final BundleCoordinate coordinate = bundle.getBundleDetails().getCoordinate();
 
-                // only include classes that meet the criteria if specified
-                if (bundleGroup != null && !bundleGroup.equals(coordinate.getGroup())) {
-                    continue;
-                }
-                if (bundleArtifact != null && !bundleArtifact.equals(coordinate.getId())) {
-                    continue;
-                }
-                if (type != null && !type.equals(cls.getName())) {
-                    continue;
-                }
-
-                final DocumentedTypeDTO dto = new DocumentedTypeDTO();
-                dto.setType(cls.getName());
-                dto.setBundle(createBundleDto(coordinate));
-                dto.setDescription(getCapabilityDescription(cls));
-                dto.setUsageRestriction(getUsageRestriction(cls));
-                dto.setTags(getTags(cls));
-                types.add(dto);
+            // only include classes that meet the criteria if specified
+            if (bundleGroupFilter != null && !bundleGroupFilter.equals(coordinate.getGroup())) {
+                continue;
             }
+            if (bundleArtifactFilter != null && !bundleArtifactFilter.equals(coordinate.getId())) {
+                continue;
+            }
+            if (typeFilter != null && !typeFilter.equals(cls.getName())) {
+                continue;
+            }
+
+            final DocumentedTypeDTO dto = new DocumentedTypeDTO();
+            dto.setType(cls.getName());
+            dto.setBundle(createBundleDto(coordinate));
+            dto.setControllerServiceApis(createControllerServiceApiDto(cls));
+            dto.setDescription(getCapabilityDescription(cls));
+            dto.setUsageRestriction(getUsageRestriction(cls));
+            dto.setTags(getTags(cls));
+            types.add(dto);
         }
 
         return types;
+    }
+
+    /**
+     * Gets the DocumentedTypeDTOs from the specified classes.
+     *
+     * @param classes classes
+     * @param bundleGroupFilter if specified, must be member of bundle group
+     * @param bundleArtifactFilter if specified, must be member of bundle artifact
+     * @param typeFilter if specified, type must match
+     * @return dtos
+     */
+    public Set<DocumentedTypeDTO> fromDocumentedTypes(final Set<Class> classes, final String bundleGroupFilter, final String bundleArtifactFilter, final String typeFilter) {
+        final Map<Class, Bundle> classBundles = new HashMap<>();
+        for (final Class cls : classes) {
+            classBundles.put(cls, ExtensionManager.getBundle(cls.getClassLoader()));
+        }
+        return fromDocumentedTypes(classBundles, bundleGroupFilter, bundleArtifactFilter, typeFilter);
     }
 
     /**
@@ -2117,6 +2182,12 @@ public final class DtoFactory {
             return null;
         }
 
+        final BundleCoordinate bundleCoordinate = node.getBundleCoordinate();
+        final List<Bundle> compatibleBundles = ExtensionManager.getBundles(node.getCanonicalClassName()).stream().filter(bundle -> {
+            final BundleCoordinate coordinate = bundle.getBundleDetails().getCoordinate();
+            return bundleCoordinate.getGroup().equals(coordinate.getGroup()) && bundleCoordinate.getId().equals(coordinate.getId());
+        }).collect(Collectors.toList());
+
         final ProcessorDTO dto = new ProcessorDTO();
         dto.setId(node.getIdentifier());
         dto.setPosition(createPositionDto(node.getPosition()));
@@ -2126,6 +2197,7 @@ public final class DtoFactory {
         dto.setPersistsState(node.getProcessor().getClass().isAnnotationPresent(Stateful.class));
         dto.setRestricted(node.isRestricted());
         dto.setExtensionMissing(node.isExtensionMissing());
+        dto.setMultipleVersionsAvailable(compatibleBundles.size() > 1);
 
         dto.setType(node.getCanonicalClassName());
         dto.setBundle(createBundleDto(node.getBundleCoordinate()));
@@ -2631,7 +2703,11 @@ public final class DtoFactory {
 
         // set the identifies controller service is applicable
         if (propertyDescriptor.getControllerServiceDefinition() != null) {
-            dto.setIdentifiesControllerService(propertyDescriptor.getControllerServiceDefinition().getName());
+            final Class serviceClass = propertyDescriptor.getControllerServiceDefinition();
+            final Bundle serviceBundle = ExtensionManager.getBundle(serviceClass.getClassLoader());
+
+            dto.setIdentifiesControllerService(serviceClass.getName());
+            dto.setIdentifiesControllerServiceBundle(createBundleDto(serviceBundle.getBundleDetails().getCoordinate()));
         }
 
         final Class<? extends ControllerService> serviceDefinition = propertyDescriptor.getControllerServiceDefinition();
@@ -2687,6 +2763,7 @@ public final class DtoFactory {
     public ControllerServiceDTO copy(final ControllerServiceDTO original) {
         final ControllerServiceDTO copy = new ControllerServiceDTO();
         copy.setAnnotationData(original.getAnnotationData());
+        copy.setControllerServiceApis(original.getControllerServiceApis());
         copy.setComments(original.getComments());
         copy.setCustomUiUrl(original.getCustomUiUrl());
         copy.setDescriptors(copy(original.getDescriptors()));
@@ -2697,6 +2774,9 @@ public final class DtoFactory {
         copy.setReferencingComponents(copy(original.getReferencingComponents()));
         copy.setState(original.getState());
         copy.setType(original.getType());
+        copy.setExtensionMissing(original.getExtensionMissing());
+        copy.setMultipleVersionsAvailable(original.getMultipleVersionsAvailable());
+        copy.setPersistsState(original.getPersistsState());
         copy.setValidationErrors(copy(original.getValidationErrors()));
         return copy;
     }
@@ -2756,6 +2836,10 @@ public final class DtoFactory {
         copy.setType(original.getType());
         copy.setSupportsParallelProcessing(original.getSupportsParallelProcessing());
         copy.setSupportsEventDriven(original.getSupportsEventDriven());
+        copy.setSupportsBatching(original.getSupportsBatching());
+        copy.setPersistsState(original.getPersistsState());
+        copy.setExtensionMissing(original.getExtensionMissing());
+        copy.setMultipleVersionsAvailable(original.getMultipleVersionsAvailable());
         copy.setValidationErrors(copy(original.getValidationErrors()));
 
         return copy;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/canvas/component-version-dialog.jsp
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/canvas/component-version-dialog.jsp
@@ -35,6 +35,12 @@
                 <div id="component-version-selector"></div>
             </div>
         </div>
+        <div id="component-version-controller-service-apis-container" class="setting hidden">
+            <div class="setting-name">Supports Controller Services</div>
+            <div class="setting-field">
+                <div id="component-version-controller-service-apis"></div>
+            </div>
+        </div>
         <div class="setting">
             <div class="setting-name">Tags</div>
             <div class="setting-field">

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/canvas/controller-service-configuration.jsp
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/canvas/controller-service-configuration.jsp
@@ -46,6 +46,10 @@
                         <div class="setting-name">Bundle</div>
                         <div id="controller-service-bundle" class="setting-field"></div>
                     </div>
+                    <div class="setting">
+                        <div class="setting-name">Supports Controller Service</div>
+                        <div id="controller-service-compatible-apis" class="setting-field"></div>
+                    </div>
                 </div>
                 <div class="spacer">&nbsp;</div>
                 <div class="settings-right">

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/css/controller-service.css
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/css/controller-service.css
@@ -218,21 +218,8 @@ div.disable-referencing-components, div.enable-referencing-components {
     New inline controller service dialog
 */
 
-div.new-inline-controller-service-combo {    width: 50%;
-    margin-bottom: 10px;
-}
-
-div.new-inline-controller-service-tags {
-    height: 18px;
-    width: 340px;
-    margin-bottom: 10px;
-    overflow: hidden;
-    white-space: nowrap;
-}
-
-div.new-inline-controller-service-description {
-    height: 115px;
-    overflow: auto;
+div.new-inline-controller-service-requirement, div.new-inline-controller-service-combo, div.new-inline-controller-service-bundle, div.new-inline-controller-service-tags {
+    margin-bottom: 15px;
 }
 
 div.new-inline-controller-service-button-container {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/css/dialog.css
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/css/dialog.css
@@ -213,7 +213,7 @@ div.progress-label {
 
 #component-version-dialog {
     width: 550px;
-    height: 525px;
+    height: 575px;
 }
 
 /*

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/combo/jquery.combo.css
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/combo/jquery.combo.css
@@ -111,7 +111,3 @@ div.combo-nifi-tooltip {
 div.combo-button-normal {
     background-color: #eaeef0;
 }
-
-span.combo-option-text {
-    max-width: 227px;
-}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-component-version.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-component-version.js
@@ -96,6 +96,10 @@
             versionMap.remove(version);
         });
 
+        // clear the service apis
+        $('#component-version-controller-service-apis').empty();
+        $('#component-version-controller-service-apis-container').hide();
+
         // clear the fields
         $('#component-version-name').text('');
         $('#component-version-bundle').text('');
@@ -125,7 +129,15 @@
             $('#component-version-restriction').addClass('unset').text('No restriction');
         }
 
-        // show the tags and description
+        // update the service apis if necessary
+        if (!common.isEmpty(documentedType.controllerServiceApis)) {
+            var formattedControllerServiceApis = common.getFormattedServiceApis(documentedType.controllerServiceApis);
+            var serviceTips = common.formatUnorderedList(formattedControllerServiceApis);
+            $('#component-version-controller-service-apis').empty().append(serviceTips);
+            $('#component-version-controller-service-apis-container').show();
+        }
+
+        // update the tags and description
         $('#component-version-tags').text(documentedType.tags.join(', '));
         $('#component-version-description').text(documentedType.description);
     };
@@ -272,9 +284,9 @@
             return $.ajax({
                 type: 'GET',
                 url: getTypeUri(componentEntity) + '?' + $.param({
-                    'bundleGroup': componentEntity.component.bundle.group,
-                    'bundleArtifact': componentEntity.component.bundle.artifact,
-                    'type': componentEntity.component.type
+                    'bundleGroupFilter': componentEntity.component.bundle.group,
+                    'bundleArtifactFilter': componentEntity.component.bundle.artifact,
+                    'typeFilter': componentEntity.component.type
                 }),
                 dataType: 'json'
             }).done(function (response) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-context-menu.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-context-menu.js
@@ -283,13 +283,13 @@
         if (selection.size() !== 1) {
             return false;
         }
-        if (nf.CanvasUtils.canRead(selection) === false || nf.CanvasUtils.canModify(selection) === false) {
+        if (canvasUtils.canRead(selection) === false || canvasUtils.canModify(selection) === false) {
             return false;
         }
 
-        if (nf.CanvasUtils.isProcessor(selection)) {
-            // TODO - only show when processor has multiple versions?
-            return true;
+        if (canvasUtils.isProcessor(selection)) {
+            var processorData = selection.datum();
+            return processorData.component.multipleVersionsAvailable === true;
         } else {
             return false;
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-controller-service.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-controller-service.js
@@ -204,6 +204,7 @@
         var controllerServiceData = controllerServiceGrid.getData();
         var currentControllerServiceEntity = controllerServiceData.getItemById(controllerServiceEntity.id);
         controllerServiceData.updateItem(controllerServiceEntity.id, $.extend({
+            type: 'ControllerService',
             bulletins: currentControllerServiceEntity.bulletins
         }, controllerServiceEntity));
     };
@@ -1679,6 +1680,9 @@
                         // clear the comments
                         common.clearField('read-only-controller-service-comments');
 
+                        // clear the compatible apis
+                        $('#controller-service-compatible-apis').empty();
+
                         // removed the cached controller service details
                         $('#controller-service-configuration').removeData('controllerServiceDetails');
                     },
@@ -1849,6 +1853,15 @@
                 $('#controller-service-name').val(controllerService['name']);
                 $('#controller-service-comments').val(controllerService['comments']);
 
+                // set the implemented apis
+                if (!common.isEmpty(controllerService['controllerServiceApis'])) {
+                    var formattedControllerServiceApis = common.getFormattedServiceApis(controllerService['controllerServiceApis']);
+                    var serviceTips = common.formatUnorderedList(formattedControllerServiceApis);
+                    $('#controller-service-compatible-apis').append(serviceTips);
+                } else {
+                    $('#controller-service-compatible-apis').append('<span class="unset">None</span>');
+                }
+
                 // get the reference container
                 var referenceContainer = $('#controller-service-referencing-components');
 
@@ -2018,6 +2031,15 @@
                 common.populateField('controller-service-bundle', common.formatBundle(controllerService['bundle']));
                 common.populateField('read-only-controller-service-name', controllerService['name']);
                 common.populateField('read-only-controller-service-comments', controllerService['comments']);
+
+                // set the implemented apis
+                if (!common.isEmpty(controllerService['controllerServiceApis'])) {
+                    var formattedControllerServiceApis = common.getFormattedServiceApis(controllerService['controllerServiceApis']);
+                    var serviceTips = common.formatUnorderedList(formattedControllerServiceApis);
+                    $('#controller-service-compatible-apis').append(serviceTips);
+                } else {
+                    $('#controller-service-compatible-apis').append('<span class="unset">None</span>');
+                }
 
                 // get the reference container
                 var referenceContainer = $('#controller-service-referencing-components');

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-controller-services.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-controller-services.js
@@ -436,6 +436,7 @@
         });
         controllerServiceTypesGrid.onViewportChanged.subscribe(function (e, args) {
             common.cleanUpTooltips($('#controller-service-types-table'), 'div.view-usage-restriction');
+            common.cleanUpTooltips($('#controller-service-types-table'), 'div.controller-service-apis');
         });
 
         // wire up the dataview to the grid
@@ -477,6 +478,35 @@
                     }));
                 }
             }
+
+            var serviceApis = $(this).find('div.controller-service-apis');
+            if (serviceApis.length && !serviceApis.data('qtip')) {
+                var rowId = $(this).find('span.row-id').text();
+
+                // get the status item
+                var item = controllerServiceTypesData.getItemById(rowId);
+
+                // show the tooltip
+                if (!common.isEmpty(item.controllerServiceApis)) {
+                    var formattedControllerServiceApis = common.getFormattedServiceApis(item.controllerServiceApis);
+                    var serviceTips = common.formatUnorderedList(formattedControllerServiceApis);
+
+                    var tipContent = $('<div style="padding: 4px;"><p>Supports Controller Services</p><br/></div>').append(serviceTips);
+
+                    serviceApis.qtip($.extend({}, common.config.tooltipConfig, {
+                        content: tipContent,
+                        position: {
+                            container: $('#summary'),
+                            at: 'bottom right',
+                            my: 'top left',
+                            adjust: {
+                                x: 4,
+                                y: 4
+                            }
+                        }
+                    }));
+                }
+            }
         });
 
         // load the available controller services
@@ -505,6 +535,7 @@
                     label: common.substringAfterLast(documentedType.type, '.'),
                     type: documentedType.type,
                     bundle: documentedType.bundle,
+                    controllerServiceApis: documentedType.controllerServiceApis,
                     description: common.escapeHtml(documentedType.description),
                     usageRestriction: common.escapeHtml(documentedType.usageRestriction),
                     tags: documentedType.tags.join(', ')
@@ -791,17 +822,19 @@
                     if (common.isEmpty(dataContext.component.validationErrors)) {
                         markup += '<div class="pointer enable-controller-service fa fa-flash" title="Enable" style="margin-top: 2px; margin-right: 3px;"></div>';
                     }
+
+                    if (dataContext.component.multipleVersionsAvailable === true) {
+                        markup += '<div title="Change Version" class="pointer change-version-controller-service fa fa-exchange" style="margin-top: 2px; margin-right: 3px;" ></div>';
+                    }
+
+                    if (canWriteControllerServiceParent(dataContext)) {
+                        markup += '<div class="pointer delete-controller-service fa fa-trash" title="Remove" style="margin-top: 2px; margin-right: 3px;" ></div>';
+                    }
                 }
 
                 if (dataContext.component.persistsState === true) {
                     markup += '<div title="View State" class="pointer view-state-controller-service fa fa-tasks" style="margin-top: 2px; margin-right: 3px;" ></div>';
                 }
-
-                if (canWriteControllerServiceParent(dataContext)) {
-                    markup += '<div class="pointer delete-controller-service fa fa-trash" title="Remove" style="margin-top: 2px; margin-right: 3px;" ></div>';
-                }
-
-                markup += '<div title="Change Version" class="pointer change-version-controller-service fa fa-exchange" style="margin-top: 2px; margin-right: 3px;" ></div>';
             }
 
             // allow policy configuration conditionally
@@ -977,7 +1010,6 @@
                             content: tooltip,
                             position: {
                                 target: 'mouse',
-                                viewport: $(window),
                                 adjust: {
                                     x: 8,
                                     y: 8,
@@ -1007,7 +1039,6 @@
                             content: tooltip,
                             position: {
                                 target: 'mouse',
-                                viewport: $(window),
                                 adjust: {
                                     x: 8,
                                     y: 8,

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-reporting-task.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-reporting-task.js
@@ -230,6 +230,7 @@
         var reportingTaskData = reportingTaskGrid.getData();
         var currentReportingTask = reportingTaskData.getItemById(reportingTaskEntity.id);
         reportingTaskData.updateItem(reportingTaskEntity.id, $.extend({
+            type: 'ReportingTask',
             bulletins: currentReportingTask.bulletins
         }, reportingTaskEntity));
     };

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-settings.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-settings.js
@@ -859,17 +859,19 @@
                     if (dataContext.component.state === 'STOPPED' && common.isEmpty(dataContext.component.validationErrors)) {
                         markup += '<div title="Start" class="pointer start-reporting-task fa fa-play" style="margin-top: 2px; margin-right: 3px;"></div>';
                     }
+
+                    if (dataContext.component.multipleVersionsAvailable === true) {
+                        markup += '<div title="Change Version" class="pointer change-version-reporting-task fa fa-exchange" style="margin-top: 2px; margin-right: 3px;" ></div>';
+                    }
+
+                    if (common.canModifyController()) {
+                        markup += '<div title="Remove" class="pointer delete-reporting-task fa fa-trash" style="margin-top: 2px; margin-right: 3px;" ></div>';
+                    }
                 }
 
                 if (dataContext.component.persistsState === true) {
                     markup += '<div title="View State" class="pointer view-state-reporting-task fa fa-tasks" style="margin-top: 2px; margin-right: 3px;" ></div>';
                 }
-
-                markup += '<div title="Change Version" class="pointer change-version-reporting-task fa fa-exchange" style="margin-top: 2px; margin-right: 3px;" ></div>';
-            }
-
-            if (dataContext.permissions.canWrite && common.canModifyController()) {
-                markup += '<div title="Remove" class="pointer delete-reporting-task fa fa-trash" style="margin-top: 2px; margin-right: 3px;" ></div>';
             }
 
             // allow policy configuration conditionally
@@ -1034,7 +1036,6 @@
                             content: tooltip,
                             position: {
                                 target: 'mouse',
-                                viewport: $(window),
                                 adjust: {
                                     x: 8,
                                     y: 8,
@@ -1064,7 +1065,6 @@
                             content: tooltip,
                             position: {
                                 target: 'mouse',
-                                viewport: $(window),
                                 adjust: {
                                     x: 8,
                                     y: 8,

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-common.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-common.js
@@ -266,11 +266,21 @@
          * @returns {string}
          */
         typeVersionFormatter: function (row, cell, value, columnDef, dataContext) {
+            var markup = '';
+
             if (nfCommon.isDefinedAndNotNull(dataContext.bundle)) {
-                return nfCommon.escapeHtml(dataContext.bundle.version);
+                markup += ('<div style="float: left;">' + nfCommon.escapeHtml(dataContext.bundle.version) + '</div>');
             } else {
-                return 'unversioned';
+                markup += '<div style="float: left;">unversioned</div>';
             }
+
+            if (!nfCommon.isEmpty(dataContext.controllerServiceApis)) {
+                markup += '<div class="controller-service-apis fa fa-list" title="Compatible Controller Service" style="margin-top: 2px; margin-left: 4px;"></div><span class="hidden row-id">' + nfCommon.escapeHtml(dataContext.id) + '</span>';
+            }
+
+            markup += '<div class="clear"></div>';
+
+            return markup;
         },
 
         /**
@@ -317,7 +327,7 @@
         formatType: function (dataContext) {
             var typeString = nfCommon.substringAfterLast(dataContext.type, '.');
             if (nfCommon.isDefinedAndNotNull(dataContext.bundle) && dataContext.bundle.version !== 'unversioned') {
-                typeString += (' - ' + dataContext.bundle.version);
+                typeString += (' ' + dataContext.bundle.version);
             }
             return typeString;
         },
@@ -716,6 +726,14 @@
                 }
                 if (!nfCommon.isBlank(propertyDescriptor.supportsEl)) {
                     tipContent.push('<b>Supports expression language:</b> ' + nfCommon.escapeHtml(propertyDescriptor.supportsEl));
+                }
+                if (!nfCommon.isBlank(propertyDescriptor.identifiesControllerService)) {
+                    var formattedType = nfCommon.formatType({
+                        'type': propertyDescriptor.identifiesControllerService,
+                        'bundle': propertyDescriptor.identifiesControllerServiceBundle
+                    });
+                    var formattedBundle = nfCommon.formatBundle(propertyDescriptor.identifiesControllerServiceBundle);
+                    tipContent.push('<b>Requires Controller Service:</b> ' + nfCommon.escapeHtml(formattedType + ' from ' + formattedBundle));
                 }
             }
 
@@ -1379,6 +1397,25 @@
                 }
             });
             return formattedBulletinEntities;
+        },
+
+        /**
+         * Formats the specified controller service list.
+         *
+         * @param {array} controllerServiceApis
+         * @returns {array}
+         */
+        getFormattedServiceApis: function (controllerServiceApis) {
+            var formattedControllerServiceApis = [];
+            $.each(controllerServiceApis, function (i, controllerServiceApi) {
+                var formattedType = nfCommon.formatType({
+                    'type': controllerServiceApi.type,
+                    'bundle': controllerServiceApi.bundle
+                });
+                var formattedBundle = nfCommon.formatBundle(controllerServiceApi.bundle);
+                formattedControllerServiceApis.push($('<div></div>').text(formattedType + ' from ' + formattedBundle));
+            });
+            return formattedControllerServiceApis;
         },
 
         getPolicyTypeListing: function (value) {


### PR DESCRIPTION
NIFI-3380:
- Requiring services/reporting tasks to be disabled/stopped.
- Only supporting a change version option when the item has multiple versions available.
- Limiting the possible new controller services to the applicable API version.
- Showing the implemented API versions for Controller Services.
- Updating the property descriptor tooltip to indicate the required service requirements.