### PR TITLE
#24 rename the nifi-reg command group to `registry` for better UX

### DIFF
--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/registry/NiFiRegistryCommandGroup.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/registry/NiFiRegistryCommandGroup.java
@@ -36,7 +36,7 @@ import java.util.List;
 public class NiFiRegistryCommandGroup extends AbstractCommandGroup {
 
     public NiFiRegistryCommandGroup() {
-        super("nifi-reg");
+        super("registry");
     }
 
     @Override


### PR DESCRIPTION
I like the new look: :)

```
#> help

commands:

	nifi current-user
	nifi get-root-id
	nifi list-reg-clients
	nifi create-reg-client
	nifi update-reg-client
	nifi pg-import
	nifi pg-start
	nifi pg-stop
	nifi pg-get-vars
	registry current-user
	registry list-buckets
	registry create-bucket
	registry list-flows
	registry create-flow
	registry list-flow-versions
	registry export-flow-version
	registry import-flow-version
	session keys
	session show
	session get
	session set
	session remove
	session clear
	exit
	help

```