### PR TITLE
Support both public URLs and local files as inputs for import actions.

### DIFF
--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/CLICompleter.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/CLICompleter.java
@@ -48,7 +48,7 @@ public class CLICompleter implements Completer {
     static {
         final Set<String> args = new HashSet<>();
         args.add("-" + CommandOption.PROPERTIES.getShortName());
-        args.add("-" + CommandOption.INPUT_FILE.getShortName());
+        args.add("-" + CommandOption.INPUT_SOURCE.getShortName());
         args.add("-" + CommandOption.OUTPUT_FILE.getShortName());
         FILE_COMPLETION_ARGS = Collections.unmodifiableSet(args);
     }

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/ProcessGroupBox.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/ProcessGroupBox.java
@@ -58,7 +58,7 @@ public class ProcessGroupBox implements Comparable<ProcessGroupBox> {
 
 
     public boolean intersects(ProcessGroupBox other) {
-        // adapted for java.awt Rectangle, we don't want to import it
+        // adapted from java.awt Rectangle, we don't want to import it
         // assume everything to be of the PG size for simplicity
         int tw = PG_SIZE_WIDTH;
         int th = PG_SIZE_HEIGHT;

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyFlowClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyFlowClient.java
@@ -108,8 +108,12 @@ public class JerseyFlowClient extends AbstractJerseyClient implements FlowClient
         pgComponents.addAll(flowDTO.getLabels());
 
         final Set<PositionDTO> positions = pgComponents.stream()
-                .map(c -> c.getPosition())
+                .map(ComponentEntity::getPosition)
                 .collect(Collectors.toSet());
+
+        if (positions.isEmpty()) {
+            return ProcessGroupBox.CANVAS_CENTER;
+        }
 
         final List<ProcessGroupBox> coords = positions.stream()
                 .map(p -> new ProcessGroupBox(p.getX().intValue(), p.getY().intValue()))

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/CommandOption.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/CommandOption.java
@@ -25,7 +25,7 @@ public enum CommandOption {
 
     // General
     URL("u", "baseUrl", "The URL to execute the command against", true),
-    INPUT_FILE("i", "inputFile", "A file to read as input, must contain full path and filename", true),
+    INPUT_SOURCE("i", "input", "A local file to read as input contents, or a public URL to fetch", true),
     OUTPUT_FILE("o", "outputFile", "A file to write output to, must contain full path and filename", true),
     PROPERTIES("p", "properties", "A properties file to load arguments from, " +
             "command line values will override anything in the properties file, must contain full path to file", true),


### PR DESCRIPTION
Assume UTF-8 charset by default for now. In theory would be possible to add more (sigh!) switches to specify a charset, but not sure it's worth it until we get further confirmation of the need.